### PR TITLE
Reduce logging when Importing Github projects

### DIFF
--- a/models/Projects/helpers.js
+++ b/models/Projects/helpers.js
@@ -44,7 +44,6 @@ module.exports.getRepoCivicJson = function getRepoCivicJson (url, user, callback
         var cj = new Buffer(parsed.content, 'base64')
         var civicJSON = cj.toString()
         civicJS = JSON.parse(civicJSON)
-        console.log('civicJSON', civicJS)
       } catch (e) {
         console.warn('Error occured', e)
       }
@@ -68,7 +67,6 @@ module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
         var parsed = JSON.parse(body)
         var rm = new Buffer(parsed.content, 'base64')
         readme = rm.toString()
-        console.log('readme', readme)
       } catch (e) {
         console.warn('Error occured', e)
       }
@@ -78,7 +76,6 @@ module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
   })
 }
 module.exports.createUpdateProjectData = function createUpdateProjectData (project, original, brigade) {
-  console.log('readme', project.readme)
   original = original || {}
   project.json = project.json || {}
   project.json.needs = project.json.needs || []

--- a/models/Projects/helpers.js
+++ b/models/Projects/helpers.js
@@ -49,7 +49,7 @@ module.exports.getRepoCivicJson = function getRepoCivicJson (url, user, callback
       }
       return callback(null, civicJS)
     }
-    callback({msg: 'Status Code not 200', response: response, body: body})
+    callback({msg: 'Status Code not 200', response: '', body: body})
   })
 }
 module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
@@ -72,7 +72,7 @@ module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
       }
       return callback(null, readme)
     }
-    callback({msg: 'Status Code not 200', response: response, body: body})
+    callback({msg: 'Status Code not 200', response: '', body: body})
   })
 }
 module.exports.createUpdateProjectData = function createUpdateProjectData (project, original, brigade) {

--- a/models/Projects/helpers.js
+++ b/models/Projects/helpers.js
@@ -49,7 +49,7 @@ module.exports.getRepoCivicJson = function getRepoCivicJson (url, user, callback
       }
       return callback(null, civicJS)
     }
-    callback({msg: 'Status Code not 200', response: '', body: body})
+    callback({msg: 'Status Code not 200', response: 'getRepoCivicJson', body: body})
   })
 }
 module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
@@ -72,7 +72,7 @@ module.exports.getRepoREADME = function getRepoREADME (url, user, callback) {
       }
       return callback(null, readme)
     }
-    callback({msg: 'Status Code not 200', response: '', body: body})
+    callback({msg: 'Status Code not 200', response: 'ReadMe Respone', body: body})
   })
 }
 module.exports.createUpdateProjectData = function createUpdateProjectData (project, original, brigade) {


### PR DESCRIPTION
This reduces the logging significantly when pulling in Github projects.  The entire readme was being sent to the console TWICE!