### PR TITLE
Only request user:email scope for login

### DIFF
--- a/app.js
+++ b/app.js
@@ -211,7 +211,7 @@ module.exports = function (opts) {
       next()
     }
     app.get('/auth/github', inspectAuth, passport.authenticate('github', {
-      scope: [ 'user:email', 'public_repo' ]
+      scope: [ 'user:email' ]
     }))
     app.get('/auth/github/elevate', inspectAuth, middleware.passport.elevateScope)
     app.get('/auth/github/callback', passport.authenticate('github', { failureRedirect: '/login' }), function (req, res) {


### PR DESCRIPTION
This removes the `public_repo` scope which grants complete write access to a user's public repositories causing trepidation for new users. This scope is not needed for basic user authentication to the site.

Opening this in part for discussion as my familiarity with the code base is pretty limited. I'm an organizer of Code for San Francisco and had some, in my view well founded, concern about granting write access to the users' repositories just to log into the site. I couldn't think offhand anywhere this scope might _actually_ be required to utilize the functionality of brigadehub, but someone please correct me.

Still trying to build this locally, but I'll look for CI failures.